### PR TITLE
Feature reorganize bottom nav links

### DIFF
--- a/src/components/BottomNav/index.tsx
+++ b/src/components/BottomNav/index.tsx
@@ -1,12 +1,15 @@
+import { useState } from "react";
 import {
   AppBar,
   BottomNavigation,
   BottomNavigationAction,
   createStyles,
   makeStyles,
+  Menu,
+  MenuItem,
 } from "@material-ui/core";
-import AddCircleIcon from "@material-ui/icons/AddCircle";
 import LocalFloristIcon from "@material-ui/icons/LocalFlorist";
+import MoreHorizIcon from "@material-ui/icons/MoreHoriz";
 import StorefrontIcon from "@material-ui/icons/Storefront";
 import EmojiNatureIcon from "@material-ui/icons/EmojiNature";
 
@@ -30,6 +33,15 @@ export const BottomNav: React.FC<BottomNavProps> = ({
   handlePageChange,
 }) => {
   const classes = useStyles();
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
   // TODO: decide how to change views on button click
 
   // TODO: Fix routes when new features are added.
@@ -43,15 +55,9 @@ export const BottomNav: React.FC<BottomNavProps> = ({
           icon={<EmojiNatureIcon />}
         ></BottomNavigationAction>
         <BottomNavigationAction
-          label="Flower Bed"
-          showLabel={true}
-          value="/user/createGarden"
-          icon={<AddCircleIcon />}
-        ></BottomNavigationAction>
-        <BottomNavigationAction
           label="Collection"
           showLabel={true}
-          value="/user/collection"
+          value="/user/myCollection"
           icon={<LocalFloristIcon />}
         ></BottomNavigationAction>
         <BottomNavigationAction
@@ -60,7 +66,26 @@ export const BottomNav: React.FC<BottomNavProps> = ({
           value="/user/store"
           icon={<StorefrontIcon />}
         ></BottomNavigationAction>
+        <BottomNavigationAction
+          label="More"
+          showLabel={true}
+          value="more"
+          icon={<MoreHorizIcon />}
+          onClick={handleClick}
+        ></BottomNavigationAction>
       </BottomNavigation>
+      <Menu
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        transitionDuration={200}
+      >
+        <MenuItem>Menu 1</MenuItem>
+        <MenuItem>Menu 2</MenuItem>
+        <MenuItem>Menu 3</MenuItem>
+        <MenuItem>Menu 4</MenuItem>
+      </Menu>
     </AppBar>
   );
 };

--- a/src/components/UserViewLayout/index.tsx
+++ b/src/components/UserViewLayout/index.tsx
@@ -17,8 +17,10 @@ export const UserViewLayout: React.FC<UserViewLayoutProps> = ({
   const [currentPage, setCurrentPage] = useState("/user/myGardens");
   const history = useHistory();
   const handlePageChange = (_event, newValue: string) => {
-    setCurrentPage(newValue);
-    history.push(newValue);
+    if (newValue !== "more") {
+      setCurrentPage(newValue);
+      history.push(newValue);
+    }
   };
   return (
     <div className={styles.layout}>

--- a/src/pages/MyGardens/index.tsx
+++ b/src/pages/MyGardens/index.tsx
@@ -1,27 +1,42 @@
+import { Grid, IconButton, Tooltip } from "@material-ui/core";
 import Card from "@material-ui/core/Card";
 import CardActionArea from "@material-ui/core/CardActionArea";
 import CardContent from "@material-ui/core/CardContent";
 import CardMedia from "@material-ui/core/CardMedia";
-import { makeStyles } from "@material-ui/core/styles";
+import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import axios from "axios";
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 import { LoadingWrapper } from "../../components/LoadingWrapper";
 import { Garden } from "../../models/garden.model";
 import { useUserState } from "../../store/user/useUserState";
+import AddIcon from "@material-ui/icons/Add";
 import gardenImage from "./assets/garden1.jpg";
 import "./MyGardens.css";
 
-const useStyles = makeStyles({
-  root: {
-    maxWidth: 845,
-  },
-  media: {
-    height: 140,
-  },
-});
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      maxWidth: 845,
+    },
+    media: {
+      height: 140,
+    },
+    myNiwaHeader: {
+      width: "100%",
+    },
+    createGarden: {
+      backgroundColor: theme.palette.primary.main,
+      color: theme.palette.background.paper,
+      alignSelf: "center",
+      "&:hover": {
+        backgroundColor: theme.palette.primary.dark,
+      },
+    },
+  })
+);
 
 export const MyGardens = () => {
   const classes = useStyles();
@@ -44,6 +59,11 @@ export const MyGardens = () => {
     getDataFromBackend();
   }, [userData]);
 
+  const history = useHistory();
+  const goToCreateGarden = () => {
+    history.push("/user/createGarden");
+  };
+
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -52,7 +72,22 @@ export const MyGardens = () => {
       exit={{ opacity: 0 }}
     >
       <div className="my-gardens-container">
-        <h1>My Gardens</h1>
+        <Grid
+          container
+          className={classes.myNiwaHeader}
+          direction="row"
+          justifyContent="space-between"
+        >
+          <h1>My Gardens</h1>
+          <Tooltip title="Add Flower Bed">
+            <IconButton
+              className={classes.createGarden}
+              onClick={goToCreateGarden}
+            >
+              <AddIcon />
+            </IconButton>
+          </Tooltip>
+        </Grid>
         <LoadingWrapper isLoading={isFetchingGardens}>
           <div className="gardens-view">
             {myGardens.map((garden, index) => {


### PR DESCRIPTION
## Description

Reorganize the bottom nav links and add a button in the myNiwa page to go to createGardens

## Closes issue(s)

Closes #111 

## How to test / reproduce

## Screenshots

<img width="415" alt="Screenshot 2021-09-07 at 00 36 32" src="https://user-images.githubusercontent.com/76471929/132239965-d28f24ce-209b-45a0-810d-64a748c151e0.png">


![update-bottom-nav-1](https://user-images.githubusercontent.com/76471929/132240009-b744c5d5-59ee-4ff6-a9ae-0afc76221ecc.gif)


## Changes include

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have tested this code

## Other comments
