### PR TITLE
add loading wrapper to collections page

### DIFF
--- a/src/pages/MyCollection/index.tsx
+++ b/src/pages/MyCollection/index.tsx
@@ -4,11 +4,12 @@ import { useEffect, useMemo } from "react";
 import { useApi } from "../../utils/api/useApi";
 import { getFlowers } from "../../helpers/api/flowers/getFlowers";
 import { useUserState } from "../../store/user/useUserState";
+import { LoadingWrapper } from "../../components/LoadingWrapper";
 
 export const MyCollection = () => {
   const [flowersAPIState, getAllFlowers] = useApi(getFlowers);
 
-  const { userData, setUserData } = useUserState();
+  const { userData } = useUserState();
 
   const allFlowers = useMemo(
     () => flowersAPIState.response ?? [],
@@ -33,7 +34,7 @@ export const MyCollection = () => {
       exit={{ opacity: 0 }}
       className="myCollectionPage"
     >
-      <div>
+      <LoadingWrapper isLoading={flowersAPIState.status === "loading"}>
         <div
           className="collection-box"
           style={{
@@ -83,7 +84,7 @@ export const MyCollection = () => {
             <div className="foreground-grass grass-animation"></div>
           </motion.div>
         </div>
-      </div>
+      </LoadingWrapper>
     </motion.div>
   );
 };


### PR DESCRIPTION
## Description

Add loading wrapper to collections/My Niwa page so that flowers dont pop in suddenly. Not sure if not including it was intentional?

## Closes issue(s)

If there any issue that is fixed with this PR, please attach it/them here...

## How to test / reproduce

## Screenshots

If you have image share...

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)

## Checklist

- [x] I have tested this code

## Other comments
